### PR TITLE
[#15] Release 편의성을 위한 Makefile을 추가한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+# Usage:
+#   GitHub Actions > Release > Run workflow에서 실행합니다.
+#
+#   version:
+#     릴리즈 버전입니다. 예: 1.0.0, 1.2.3-beta.1
+#
+#   operation:
+#     release        새 태그를 생성하고 GitHub Release를 만듭니다.
+#     retag-release  기존 태그를 target_branch의 현재 HEAD로 강제 이동합니다.
+#
+#   target_branch:
+#     릴리즈 기준 브랜치입니다. 기본값은 main입니다.
+#
+# Permissions:
+#   tags push와 GitHub Release 생성을 위해 contents: write 권한이 필요합니다.
+#   레포 설정의 Actions > Workflow permissions에서 Read and write permissions가 허용되어야 합니다.
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. 1.0.0"
+        required: true
+        type: string
+      operation:
+        description: "Release operation"
+        required: true
+        default: "release"
+        type: choice
+        options:
+          - release
+          - retag-release
+      target_branch:
+        description: "Branch to release from"
+        required: true
+        default: "main"
+        type: string
+
+run-name: "${{ inputs.operation }} ${{ inputs.version }} from ${{ inputs.target_branch }}"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            echo "Use a SemVer-like value such as 1.0.0."
+            exit 1
+          fi
+
+      - name: Create release
+        if: inputs.operation == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag already exists: $VERSION"
+            exit 1
+          fi
+
+          git tag -a "$VERSION" -m "release: $VERSION"
+          git push origin "$VERSION"
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "Release $VERSION"
+
+      - name: Move existing tag
+        if: inputs.operation == 'retag-release'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag -fa "$VERSION" -m "release: $VERSION"
+          git push origin "$VERSION" --force

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# Usage:
+#   이 Makefile은 scripts/release.sh 쉘 스크립트를 활용해 릴리즈 명령을 실행합니다.
+#
+#   make help
+#       사용 가능한 명령을 출력합니다.
+#
+#   make release 1.0.0
+#       main 브랜치를 pull한 뒤 1.0.0 태그와 GitHub Release를 생성합니다.
+#
+#   make retag-release 1.0.0
+#       1.0.0 태그를 현재 HEAD로 강제 이동하고 origin에 force push합니다.
+
+.DEFAULT_GOAL := all
+
+VERSION := $(word 2,$(MAKECMDGOALS))
+
+.PHONY: all help release retag-release
+
+all: help
+
+help:
+	@echo "사용법:"
+	@echo "  make release <version>        새 릴리즈 태그와 GitHub Release 생성"
+	@echo "  make retag-release <version>  기존 태그를 현재 HEAD로 이동 후 force push"
+
+release:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "❌ 버전을 입력하세요."; \
+		echo "예: make release 1.0.0"; \
+		exit 1; \
+	fi
+	bash scripts/release.sh "$(VERSION)"
+
+retag-release:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "❌ 버전을 입력하세요."; \
+		echo "예: make retag-release 1.0.0"; \
+		exit 1; \
+	fi
+	@echo "⚠️ $(VERSION) 태그를 현재 HEAD로 이동합니다."
+	git tag -fa "$(VERSION)" -m "release: $(VERSION)"
+	git push origin "$(VERSION)" --force
+
+%:
+	@:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "❌ 버전을 입력하세요."
+  echo "예: ./release.sh 1.0.0"
+  exit 1
+fi
+
+echo "🚀 Release version: $VERSION"
+
+# 최신 코드 가져오기
+git pull origin main
+
+# 태그 생성
+# 현재 커밋을 4.7.0 버전 태그로 표시하고 메시지를 "release: 4.7.0" 로 남긴다
+git tag -a "$VERSION" -m "release: $VERSION"
+
+# 태그 push
+git push origin "$VERSION"
+
+# GitHub Release 생성
+gh release create "$VERSION" \
+  --title "$VERSION" \
+  --notes "Release $VERSION"
+
+echo "✅ Release $VERSION 완료"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -euo pipefail
 VERSION=$1
 
 if [ -z "$VERSION" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-VERSION=$1
+
+VERSION=${1:-}
 
 if [ -z "$VERSION" ]; then
   echo "❌ 버전을 입력하세요."


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정
- [x] CI: CI/CD 및 GitHub Actions 작업 및 수정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- scripts/* 추가
- makefile 추가

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #15 

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

라이브러리 확장을 고려하고, SPM에서 버전별 import를 지원하기 위해 git tag 관리가 필요하다고 판단했습니다.
이를 자동화하기 위한 스크립트를 작성했으며, 기능이 어느 정도 추가된 시점에 main 브랜치에서 실행합니다.
```bash
# 사용 가능한 명령을 출력합니다.
make help

# main 브랜치를 pull한 뒤 1.0.0 태그와 GitHub Release를 생성합니다.
make release 1.0.0

# (긴급) 기존 released된 1.0.0 태그를 현재 HEAD로 강제 이동하고 origin에 force push합니다.
make retag-release 1.0.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 릴리스 자동화 도구 추가 — 로컬 명령으로 배포 및 태그 작업 수행 가능
  * 릴리스 스크립트 추가 — 버전 기반 태그 생성 및 GitHub 릴리스 생성 지원
  * GitHub Actions 워크플로우 추가 — 수동 트리거로 버전/작업 선택 가능, 기존 태그 생성 및 강제 재태그 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->