### PR TITLE
[#17] SKTextField에 onSubmit 모디파이어를 구성한다

### DIFF
--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
@@ -104,8 +104,8 @@ private struct SampleSKTextFieldSubmitSummary: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("마지막 제출 값: \(submittedLabel)")
-            Text("제출 횟수: \(submitCount)")
+            Text("마지막 Submit 값: \(submittedLabel)")
+            Text("Submit 횟수: \(submitCount)")
         }
         .font(.caption)
         .foregroundStyle(.secondary)

--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
@@ -50,7 +50,7 @@ struct SampleSKTextFieldOnSubmitTabView: View {
                     SampleSKTextFieldBlock(
                         text: $multiLineText,
                         title: "여러 줄 입력",
-                        axisDescription: "return 키 입력 시 줄바꿈 대신 onSubmit 실행",
+                        axisDescription: "하드웨어 키보드 Return은 onSubmit, 소프트웨어 키보드 Return은 줄바꿈",
                         field: {
                             SKTextField(
                                 "메시지를 입력해 주세요",

--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldOnSubmitTabView.swift
@@ -1,0 +1,121 @@
+//
+//  SampleSKTextFieldOnSubmitTabView.swift
+//  SwiftUI-Kit
+//
+//  Created by opfic on 4/20/26.
+//
+
+import SwiftUI
+import SwiftUI_Kit
+
+struct SampleSKTextFieldOnSubmitTabView: View {
+    @State private var singleLineText = ""
+    @State private var multiLineText = ""
+    @State private var submittedSingleLineText = ""
+    @State private var submittedMultiLineText = ""
+    @State private var singleLineSubmitCount = 0
+    @State private var multiLineSubmitCount = 0
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("한 줄 입력") {
+                    SampleSKTextFieldBlock(
+                        text: $singleLineText,
+                        title: "한 줄 입력",
+                        axisDescription: "return 키 입력 시 onSubmit 실행",
+                        field: {
+                            SKTextField(
+                                "메시지를 입력해 주세요",
+                                text: $singleLineText,
+                                axis: .horizontal
+                            )
+                            .onSubmit {
+                                submitSingleLineText()
+                            }
+                        }
+                    )
+
+                    SampleSKTextFieldSubmitSummary(
+                        submittedText: submittedSingleLineText,
+                        submitCount: singleLineSubmitCount
+                    )
+
+                    Button("상태 초기화") {
+                        resetSingleLineSubmitState()
+                    }
+                }
+
+                Section("여러 줄 입력") {
+                    SampleSKTextFieldBlock(
+                        text: $multiLineText,
+                        title: "여러 줄 입력",
+                        axisDescription: "return 키 입력 시 줄바꿈 대신 onSubmit 실행",
+                        field: {
+                            SKTextField(
+                                "메시지를 입력해 주세요",
+                                text: $multiLineText,
+                                axis: .vertical
+                            )
+                            .onSubmit {
+                                submitMultiLineText()
+                            }
+                        }
+                    )
+
+                    SampleSKTextFieldSubmitSummary(
+                        submittedText: submittedMultiLineText,
+                        submitCount: multiLineSubmitCount
+                    )
+
+                    Button("상태 초기화") {
+                        resetMultiLineSubmitState()
+                    }
+                }
+            }
+            .navigationTitle("onSubmit")
+        }
+    }
+
+    private func submitSingleLineText() {
+        submittedSingleLineText = singleLineText
+        singleLineSubmitCount += 1
+    }
+
+    private func submitMultiLineText() {
+        submittedMultiLineText = multiLineText
+        multiLineSubmitCount += 1
+    }
+
+    private func resetSingleLineSubmitState() {
+        submittedSingleLineText = ""
+        singleLineSubmitCount = 0
+    }
+
+    private func resetMultiLineSubmitState() {
+        submittedMultiLineText = ""
+        multiLineSubmitCount = 0
+    }
+}
+
+private struct SampleSKTextFieldSubmitSummary: View {
+    let submittedText: String
+    let submitCount: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("마지막 제출 값: \(submittedLabel)")
+            Text("제출 횟수: \(submitCount)")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    private var submittedLabel: String {
+        if submittedText.isEmpty {
+            return "없음"
+        }
+
+        return submittedText
+    }
+}

--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldView.swift
@@ -25,6 +25,11 @@ public struct SampleSKTextFieldView: View {
                 .tabItem {
                     Label("문자열", systemImage: "character")
                 }
+
+            SampleSKTextFieldOnSubmitTabView()
+                .tabItem {
+                    Label("onSubmit", systemImage: "arrow.turn.down.left")
+                }
         }
     }
 }

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -173,6 +173,9 @@ public struct SKTextField<Label: View>: View {
     /// onSubmit 시 실행할 동작을 등록합니다.
     ///
     /// SwiftUI `View.onSubmit(_:)`와 같은 형태로 사용할 수 있습니다.
+    /// `SKTextField`가 한 줄 입력(`axis: .horizontal`)인 경우에는 Return 입력 시 `onSubmit`이 실행됩니다.
+    /// 여러 줄 입력(`axis: .vertical`)인 경우에는 소프트웨어 키보드의 Return 입력이 줄바꿈으로 처리되고,
+    /// 하드웨어 키보드의 Return 입력일 때만 `onSubmit`이 실행됩니다.
     ///
     /// ## 사용 예시
     /// ```swift

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -45,6 +45,7 @@ public struct SKTextField<Label: View>: View {
     private let title: Title
     private var focusValue: (() -> Bool)?
     private var onFocusChange: ((Bool) -> Void)?
+    private var focusModifier: ((AnyView) -> AnyView)?
     private var onSubmitAction: (() -> Void)?
     
     /// 로컬라이즈된 제목 문자열로 텍스트 필드를 생성합니다.
@@ -138,27 +139,35 @@ public struct SKTextField<Label: View>: View {
     }
     
     public var body: some View {
-        SKTextFieldPresentable(
-            text: $text,
-            axis: axis,
-            placeholder: placeholder,
-            accessibilityLabel: accessibilityLabel,
-            onSubmit: submitAction,
-            focusBinding: {
-                if let focusValue, let onFocusChange {
-                    return Binding(
-                        get: {
-                            focusValue()
-                        },
-                        set: { newValue in
-                            onFocusChange(newValue)
-                        }
-                    )
-                }
-                
-                return nil
-            }()
+        let content = AnyView(
+            SKTextFieldPresentable(
+                text: $text,
+                axis: axis,
+                placeholder: placeholder,
+                accessibilityLabel: accessibilityLabel,
+                onSubmit: submitAction,
+                focusBinding: {
+                    if let focusValue, let onFocusChange {
+                        return Binding(
+                            get: {
+                                focusValue()
+                            },
+                            set: { newValue in
+                                onFocusChange(newValue)
+                            }
+                        )
+                    }
+
+                    return nil
+                }()
+            )
         )
+
+        if let focusModifier {
+            return focusModifier(content)
+        }
+
+        return content
     }
 
     /// onSubmit 시 실행할 동작을 등록합니다.
@@ -211,7 +220,7 @@ public struct SKTextField<Label: View>: View {
     /// SKTextField("이름", text: $name)
     ///     .focused($isNameFocused)
     /// ```
-    public func focused(_ condition: FocusState<Bool>.Binding) -> some View {
+    public func focused(_ condition: FocusState<Bool>.Binding) -> Self {
         var copy = self
         copy.focusValue = {
             condition.wrappedValue
@@ -221,9 +230,11 @@ public struct SKTextField<Label: View>: View {
                 condition.wrappedValue = newValue
             }
         }
-        
-        return AnyView(copy)
-            .focused(condition)
+        copy.focusModifier = { content in
+            AnyView(content.focused(condition))
+        }
+
+        return copy
     }
     
     /// 값 비교 기반 `FocusState`와 텍스트 필드를 연결합니다.
@@ -249,7 +260,7 @@ public struct SKTextField<Label: View>: View {
     public func focused<Value>(
         _ binding: FocusState<Value?>.Binding,
         equals value: Value
-    ) -> some View where Value: Hashable {
+    ) -> Self where Value: Hashable {
         var copy = self
         copy.focusValue = {
             binding.wrappedValue == value
@@ -263,12 +274,16 @@ public struct SKTextField<Label: View>: View {
                 }
             }
         }
-        
-        return AnyView(copy)
-            .focused(
-                binding,
-                equals: value
+        copy.focusModifier = { content in
+            AnyView(
+                content.focused(
+                    binding,
+                    equals: value
+                )
             )
+        }
+
+        return copy
     }
     
     private var placeholder: String {

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -45,7 +45,6 @@ public struct SKTextField<Label: View>: View {
     private let title: Title
     private var focusValue: (() -> Bool)?
     private var onFocusChange: ((Bool) -> Void)?
-    private var submitTriggers: SubmitTriggers = []
     private var onSubmitAction: (() -> Void)?
     
     /// 로컬라이즈된 제목 문자열로 텍스트 필드를 생성합니다.
@@ -164,7 +163,7 @@ public struct SKTextField<Label: View>: View {
 
     /// onSubmit 시 실행할 동작을 등록합니다.
     ///
-    /// SwiftUI `View.onSubmit(of:_:)`와 같은 형태로 사용할 수 있습니다.
+    /// SwiftUI `View.onSubmit(_:)`와 같은 형태로 사용할 수 있습니다.
     ///
     /// ## 사용 예시
     /// ```swift
@@ -187,16 +186,10 @@ public struct SKTextField<Label: View>: View {
     ///     }
     /// ```
     ///
-    /// - Parameters:
-    ///   - triggers: onSubmit을 수신할 트리거입니다. `SKTextField`는 `.text`만 처리합니다.
-    ///   - action: onSubmit 시 실행할 클로저입니다.
-    public func onSubmit(
-        of triggers: SubmitTriggers = .text,
-        _ action: @escaping () -> Void
-    ) -> Self {
+    /// - Parameter action: onSubmit 시 실행할 클로저입니다.
+    public func onSubmit(_ action: @escaping () -> Void) -> Self {
         var copy = self
         let previousAction = copy.onSubmitAction
-        copy.submitTriggers.formUnion(triggers)
         copy.onSubmitAction = {
             previousAction?()
             action()
@@ -301,10 +294,6 @@ public struct SKTextField<Label: View>: View {
     }
 
     private var submitAction: (() -> Void)? {
-        guard submitTriggers.contains(.text) else {
-            return nil
-        }
-
         return onSubmitAction
     }
     

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -45,6 +45,8 @@ public struct SKTextField<Label: View>: View {
     private let title: Title
     private var focusValue: (() -> Bool)?
     private var onFocusChange: ((Bool) -> Void)?
+    private var submitTriggers: SubmitTriggers = []
+    private var onSubmitAction: (() -> Void)?
     
     /// 로컬라이즈된 제목 문자열로 텍스트 필드를 생성합니다.
     ///
@@ -142,6 +144,7 @@ public struct SKTextField<Label: View>: View {
             axis: axis,
             placeholder: placeholder,
             accessibilityLabel: accessibilityLabel,
+            onSubmit: submitAction,
             focusBinding: {
                 if let focusValue, let onFocusChange {
                     return Binding(
@@ -253,6 +256,14 @@ public struct SKTextField<Label: View>: View {
         case .plain(let plainText):
             return plainText
         }
+    }
+
+    private var submitAction: (() -> Void)? {
+        guard submitTriggers.contains(.text) else {
+            return nil
+        }
+
+        return onSubmitAction
     }
     
     private enum Title {

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -161,6 +161,48 @@ public struct SKTextField<Label: View>: View {
             }()
         )
     }
+
+    /// 텍스트 제출 시 실행할 동작을 등록합니다.
+    ///
+    /// SwiftUI `View.onSubmit(of:_:)`와 같은 형태로 사용할 수 있습니다.
+    ///
+    /// ## 사용 예시
+    /// ```swift
+    /// @State private var message = ""
+    /// @State private var submittedMessage = ""
+    ///
+    /// SKTextField("메시지", text: $message)
+    ///     .onSubmit {
+    ///         submittedMessage = message
+    ///     }
+    /// ```
+    ///
+    /// ```swift
+    /// @State private var note = ""
+    /// @State private var submittedNote = ""
+    ///
+    /// SKTextField("메모", text: $note, axis: .vertical)
+    ///     .onSubmit {
+    ///         submittedNote = note
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - triggers: 제출을 수신할 트리거입니다. `SKTextField`는 `.text`만 처리합니다.
+    ///   - action: 제출 시 실행할 클로저입니다.
+    public func onSubmit(
+        of triggers: SubmitTriggers = .text,
+        _ action: @escaping () -> Void
+    ) -> Self {
+        var copy = self
+        let previousAction = copy.onSubmitAction
+        copy.submitTriggers.formUnion(triggers)
+        copy.onSubmitAction = {
+            previousAction?()
+            action()
+        }
+        return copy
+    }
     
     /// `Bool` 기반 `FocusState`와 텍스트 필드를 연결합니다.
     ///

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -162,7 +162,7 @@ public struct SKTextField<Label: View>: View {
         )
     }
 
-    /// 텍스트 제출 시 실행할 동작을 등록합니다.
+    /// onSubmit 시 실행할 동작을 등록합니다.
     ///
     /// SwiftUI `View.onSubmit(of:_:)`와 같은 형태로 사용할 수 있습니다.
     ///
@@ -188,8 +188,8 @@ public struct SKTextField<Label: View>: View {
     /// ```
     ///
     /// - Parameters:
-    ///   - triggers: 제출을 수신할 트리거입니다. `SKTextField`는 `.text`만 처리합니다.
-    ///   - action: 제출 시 실행할 클로저입니다.
+    ///   - triggers: onSubmit을 수신할 트리거입니다. `SKTextField`는 `.text`만 처리합니다.
+    ///   - action: onSubmit 시 실행할 클로저입니다.
     public func onSubmit(
         of triggers: SubmitTriggers = .text,
         _ action: @escaping () -> Void

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldContainer.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldContainer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class SKTextFieldContainer: UIView {
     let uiTextField: UITextField?
-    let uiTextView: UITextView?
+    let uiTextView: SKTextView?
     
     private let axis: Axis
     private var lastIntrinsicContentSize: CGSize?
@@ -22,7 +22,7 @@ final class SKTextFieldContainer: UIView {
             uiTextView = nil
         } else {
             uiTextField = nil
-            uiTextView = UITextView()
+            uiTextView = SKTextView()
         }
         
         super.init(frame: .zero)

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -93,7 +93,8 @@ struct SKTextFieldPresentable: UIViewRepresentable {
 }
 
 extension SKTextFieldPresentable {
-    final class Coordinator: NSObject, UITextFieldDelegate, UITextViewDelegate {
+    @MainActor
+    final class Coordinator: NSObject {
         var parent: SKTextFieldPresentable
 
         private weak var scrollView: UIScrollView?
@@ -109,80 +110,6 @@ extension SKTextFieldPresentable {
         @objc
         func textFieldDidChange(_ uiTextField: UITextField) {
             parent.text = uiTextField.text ?? ""
-        }
-
-        func textFieldDidBeginEditing(_ uiTextField: UITextField) {
-            if let focusBinding = parent.focusBinding, !focusBinding.wrappedValue {
-                focusBinding.wrappedValue = true
-            }
-        }
-
-        func textFieldDidEndEditing(_ uiTextField: UITextField) {
-            if let focusBinding = parent.focusBinding, focusBinding.wrappedValue {
-                focusBinding.wrappedValue = false
-            }
-        }
-
-        func textFieldShouldReturn(_ uiTextField: UITextField) -> Bool {
-            parent.onSubmit?()
-            return true
-        }
-
-        func textViewShouldBeginEditing(_ uiTextView: UITextView) -> Bool {
-            startTrackingOffset(for: uiTextView)
-            return true
-        }
-
-        func textViewDidBeginEditing(_ uiTextView: UITextView) {
-            if isShowingPlaceholder {
-                uiTextView.text = nil
-                uiTextView.textColor = .label
-                isShowingPlaceholder = false
-            }
-
-            if let focusBinding = parent.focusBinding, !focusBinding.wrappedValue {
-                focusBinding.wrappedValue = true
-            }
-
-            restoreOffsetIfNeeded()
-
-            DispatchQueue.main.async { [weak self] in
-                self?.restoreOffsetIfNeeded()
-                uiTextView.invalidateIntrinsicContentSize()
-                uiTextView.superview?.invalidateIntrinsicContentSize()
-            }
-        }
-
-        func textViewDidChange(_ uiTextView: UITextView) {
-            stopTrackingOffset()
-            parent.text = uiTextView.text
-            isShowingPlaceholder = false
-            uiTextView.invalidateIntrinsicContentSize()
-            uiTextView.superview?.invalidateIntrinsicContentSize()
-        }
-
-        func textViewDidEndEditing(_ uiTextView: UITextView) {
-            if let focusBinding = parent.focusBinding, focusBinding.wrappedValue {
-                focusBinding.wrappedValue = false
-            }
-
-            stopTrackingOffset()
-            applyPlaceholderIfNeeded(to: uiTextView)
-            uiTextView.invalidateIntrinsicContentSize()
-            uiTextView.superview?.invalidateIntrinsicContentSize()
-        }
-
-        func textView(
-            _ uiTextView: UITextView,
-            shouldChangeTextIn range: NSRange,
-            replacementText text: String
-        ) -> Bool {
-            guard text == "\n", parent.onSubmit != nil else {
-                return true
-            }
-
-            parent.onSubmit?()
-            return false
         }
 
         func applyConfiguration(to container: SKTextFieldContainer) {
@@ -317,6 +244,83 @@ extension SKTextFieldPresentable {
             scrollView = nil
             trackedOffset = nil
         }
+
+        func updateFocus(_ isFocused: Bool) {
+            if let focusBinding = parent.focusBinding,
+               focusBinding.wrappedValue != isFocused {
+                focusBinding.wrappedValue = isFocused
+            }
+        }
+
+        func invalidateTextViewLayout(_ uiTextView: UITextView) {
+            uiTextView.invalidateIntrinsicContentSize()
+            uiTextView.superview?.invalidateIntrinsicContentSize()
+        }
+    }
+}
+
+extension SKTextFieldPresentable.Coordinator: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ uiTextField: UITextField) {
+        updateFocus(true)
+    }
+
+    func textFieldDidEndEditing(_ uiTextField: UITextField) {
+        updateFocus(false)
+    }
+
+    func textFieldShouldReturn(_ uiTextField: UITextField) -> Bool {
+        parent.onSubmit?()
+        return true
+    }
+}
+
+extension SKTextFieldPresentable.Coordinator: UITextViewDelegate {
+    func textViewShouldBeginEditing(_ uiTextView: UITextView) -> Bool {
+        startTrackingOffset(for: uiTextView)
+        return true
+    }
+
+    func textViewDidBeginEditing(_ uiTextView: UITextView) {
+        if isShowingPlaceholder {
+            uiTextView.text = nil
+            uiTextView.textColor = .label
+            isShowingPlaceholder = false
+        }
+
+        updateFocus(true)
+        restoreOffsetIfNeeded()
+
+        DispatchQueue.main.async { [weak self] in
+            self?.restoreOffsetIfNeeded()
+            self?.invalidateTextViewLayout(uiTextView)
+        }
+    }
+
+    func textViewDidChange(_ uiTextView: UITextView) {
+        stopTrackingOffset()
+        parent.text = uiTextView.text
+        isShowingPlaceholder = false
+        invalidateTextViewLayout(uiTextView)
+    }
+
+    func textViewDidEndEditing(_ uiTextView: UITextView) {
+        updateFocus(false)
+        stopTrackingOffset()
+        applyPlaceholderIfNeeded(to: uiTextView)
+        invalidateTextViewLayout(uiTextView)
+    }
+
+    func textView(
+        _ uiTextView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        guard text == "\n", parent.onSubmit != nil else {
+            return true
+        }
+
+        parent.onSubmit?()
+        return false
     }
 }
 

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -122,6 +122,14 @@ extension SKTextFieldPresentable {
 
             if let uiTextView = container.uiTextView {
                 applyPlaceholderIfNeeded(to: uiTextView)
+                if parent.onSubmit == nil {
+                    uiTextView.onHardwareSubmit = nil
+                } else {
+                    uiTextView.onHardwareSubmit = {
+                        [weak self] in
+                        self?.handleHardwareSubmit()
+                    }
+                }
             }
         }
 
@@ -256,6 +264,10 @@ extension SKTextFieldPresentable {
             uiTextView.invalidateIntrinsicContentSize()
             uiTextView.superview?.invalidateIntrinsicContentSize()
         }
+
+        func handleHardwareSubmit() {
+            parent.onSubmit?()
+        }
     }
 }
 
@@ -308,19 +320,6 @@ extension SKTextFieldPresentable.Coordinator: UITextViewDelegate {
         stopTrackingOffset()
         applyPlaceholderIfNeeded(to: uiTextView)
         invalidateTextViewLayout(uiTextView)
-    }
-
-    func textView(
-        _ uiTextView: UITextView,
-        shouldChangeTextIn range: NSRange,
-        replacementText text: String
-    ) -> Bool {
-        guard text == "\n", parent.onSubmit != nil else {
-            return true
-        }
-
-        parent.onSubmit?()
-        return false
     }
 }
 

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -12,6 +12,7 @@ struct SKTextFieldPresentable: UIViewRepresentable {
     let axis: Axis
     let placeholder: String
     let accessibilityLabel: String?
+    let onSubmit: (() -> Void)?
     let focusBinding: Binding<Bool>?
 
     func makeCoordinator() -> Coordinator {
@@ -92,7 +93,6 @@ struct SKTextFieldPresentable: UIViewRepresentable {
 }
 
 extension SKTextFieldPresentable {
-
     final class Coordinator: NSObject, UITextFieldDelegate, UITextViewDelegate {
         var parent: SKTextFieldPresentable
 
@@ -121,6 +121,11 @@ extension SKTextFieldPresentable {
             if let focusBinding = parent.focusBinding, focusBinding.wrappedValue {
                 focusBinding.wrappedValue = false
             }
+        }
+
+        func textFieldShouldReturn(_ uiTextField: UITextField) -> Bool {
+            parent.onSubmit?()
+            return true
         }
 
         func textViewShouldBeginEditing(_ uiTextView: UITextView) -> Bool {
@@ -165,6 +170,19 @@ extension SKTextFieldPresentable {
             applyPlaceholderIfNeeded(to: uiTextView)
             uiTextView.invalidateIntrinsicContentSize()
             uiTextView.superview?.invalidateIntrinsicContentSize()
+        }
+
+        func textView(
+            _ uiTextView: UITextView,
+            shouldChangeTextIn range: NSRange,
+            replacementText text: String
+        ) -> Bool {
+            guard text == "\n", parent.onSubmit != nil else {
+                return true
+            }
+
+            parent.onSubmit?()
+            return false
         }
 
         func applyConfiguration(to container: SKTextFieldContainer) {

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -282,6 +282,7 @@ extension SKTextFieldPresentable.Coordinator: UITextFieldDelegate {
 
     func textFieldShouldReturn(_ uiTextField: UITextField) -> Bool {
         parent.onSubmit?()
+        uiTextField.resignFirstResponder()
         return true
     }
 }

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextView.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextView.swift
@@ -10,7 +10,7 @@ import UIKit
 final class SKTextView: UITextView {
     var onHardwareSubmit: (() -> Void)?
 
-    // 하드웨어 키보드의 엔터키 입력을 먼저 감지해 제출 처리 여부를 판단한다.
+    // 하드웨어 키보드의 엔터키 입력을 먼저 감지해 onbSubmit 처리 여부를 판단한다.
     override func pressesBegan(
         _ uiPresses: Set<UIPress>,
         with uiPressesEvent: UIPressesEvent?
@@ -31,7 +31,7 @@ final class SKTextView: UITextView {
         resignFirstResponder()
     }
 
-    // 전달된 키 입력이 onSubmit로 처리되어야 하는 경우 즉시 제출 동작을 수행한다.
+    // 전달된 키 입력이 onSubmit로 처리되어야 하는 경우 즉시 동작을 수행한다.
     private func handleHardwareSubmitIfNeeded(
         for uiPresses: Set<UIPress>
     ) -> Bool {

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextView.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextView.swift
@@ -1,0 +1,76 @@
+//
+//  SKTextView.swift
+//  SwiftUI-Kit
+//
+//  Created by opfic on 4/20/26.
+//
+
+import UIKit
+
+final class SKTextView: UITextView {
+    var onHardwareSubmit: (() -> Void)?
+
+    // 하드웨어 키보드의 엔터키 입력을 먼저 감지해 제출 처리 여부를 판단한다.
+    override func pressesBegan(
+        _ uiPresses: Set<UIPress>,
+        with uiPressesEvent: UIPressesEvent?
+    ) {
+        if handleHardwareSubmitIfNeeded(for: uiPresses) {
+            return
+        }
+
+        super.pressesBegan(
+            uiPresses,
+            with: uiPressesEvent
+        )
+    }
+
+    // onSubmit 동작을 실행한 뒤 포커스를 해제한다.
+    func triggerHardwareSubmit() {
+        onHardwareSubmit?()
+        resignFirstResponder()
+    }
+
+    // 전달된 키 입력이 onSubmit로 처리되어야 하는 경우 즉시 제출 동작을 수행한다.
+    private func handleHardwareSubmitIfNeeded(
+        for uiPresses: Set<UIPress>
+    ) -> Bool {
+        guard onHardwareSubmit != nil else {
+            return false
+        }
+
+        guard uiPresses.contains(
+            where: isUnmodifiedReturnKeyPress
+        ) else {
+            return false
+        }
+
+        triggerHardwareSubmit()
+        return true
+    }
+
+    // 수정 키 없이 눌린 Return 키인지 판별한다.
+    private func isUnmodifiedReturnKeyPress(
+        _ uiPress: UIPress
+    ) -> Bool {
+        guard let uiKey = uiPress.key else {
+            return false
+        }
+
+        let submitModifierFlags: UIKeyModifierFlags = [
+            .alternate,
+            .command,
+            .control,
+            .shift
+        ]
+
+        guard uiKey.modifierFlags
+            .intersection(submitModifierFlags)
+            .isEmpty else { return false }
+
+        let ignoringModifiers = uiKey.charactersIgnoringModifiers
+        return
+            ignoringModifiers == "\r" ||
+            ignoringModifiers == "\n"
+    }
+}

--- a/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
@@ -153,8 +153,8 @@ struct SKTextFieldTests {
         #expect(submitModel.submitCount == 1)
     }
 
-    @Test("onSubmit은 vertical SKTextField 제출 시 실행된다")
-    func onSubmit_verticalTextView() {
+    @Test("onSubmit은 vertical SKTextField에서 소프트웨어 개행을 허용한다")
+    func onSubmit_verticalTextView_withSoftwareKeyboard() {
         let submitModel = SubmitModel()
         let uiTextView = makeTextView(
             rootView: SubmitVerticalHostView(
@@ -162,14 +162,37 @@ struct SKTextFieldTests {
             )
         )
 
-        let shouldChange = uiTextView.delegate?.textView?(
-            uiTextView,
-            shouldChangeTextIn: NSRange(location: 0, length: 0),
-            replacementText: "\n"
+        let becomeFirstResponder = uiTextView.becomeFirstResponder()
+        runMainLoop()
+
+        uiTextView.insertText("A")
+        uiTextView.insertText("\n")
+        runMainLoop()
+
+        #expect(becomeFirstResponder == true)
+        #expect(uiTextView.text == "A\n")
+        #expect(submitModel.submitCount == 0)
+    }
+
+    @Test("onSubmit은 vertical SKTextField에서 하드웨어 제출 후 포커스를 해제한다")
+    func onSubmit_verticalTextView_withHardwareKeyboard() {
+        let submitModel = SubmitModel()
+        let uiTextView = makeTextView(
+            rootView: SubmitVerticalHostView(
+                submitModel: submitModel
+            )
         )
 
-        #expect(shouldChange == false)
+        let becomeFirstResponder = uiTextView.becomeFirstResponder()
+        runMainLoop()
+
+        (uiTextView as? SKTextView)?
+            .triggerHardwareSubmit()
+        runMainLoop()
+
+        #expect(becomeFirstResponder == true)
         #expect(submitModel.submitCount == 1)
+        #expect(uiTextView.isFirstResponder == false)
     }
 }
 

--- a/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
@@ -200,6 +200,7 @@ struct SKTextFieldTests {
         #expect(submitModel.submitCount == 1)
         #expect(uiTextView.isFirstResponder == false)
     }
+
 }
 
 private extension SKTextFieldTests {
@@ -328,7 +329,7 @@ private extension SKTextFieldTests {
             }
         }
     }
-    
+
     func makeTextField<Content: View>(
         rootView: Content
     ) -> UITextField {

--- a/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
@@ -139,7 +139,7 @@ struct SKTextFieldTests {
         #expect(uiTextView.textColor == .label)
     }
 
-    @Test("onSubmit은 horizontal SKTextField 제출 시 실행된다")
+    @Test("onSubmit은 horizontal SKTextField에서 동작 후 포커스를 해제한다")
     func onSubmit_horizontalTextField() {
         let submitModel = SubmitModel()
         let uiTextField = makeTextField(
@@ -148,9 +148,15 @@ struct SKTextFieldTests {
             )
         )
 
-        _ = uiTextField.delegate?.textFieldShouldReturn?(uiTextField)
+        let becomeFirstResponder = uiTextField.becomeFirstResponder()
+        runMainLoop()
 
+        _ = uiTextField.delegate?.textFieldShouldReturn?(uiTextField)
+        runMainLoop()
+
+        #expect(becomeFirstResponder == true)
         #expect(submitModel.submitCount == 1)
+        #expect(uiTextField.isFirstResponder == false)
     }
 
     @Test("onSubmit은 vertical SKTextField에서 소프트웨어 개행을 허용한다")
@@ -174,7 +180,7 @@ struct SKTextFieldTests {
         #expect(submitModel.submitCount == 0)
     }
 
-    @Test("onSubmit은 vertical SKTextField에서 하드웨어 제출 후 포커스를 해제한다")
+    @Test("onSubmit은 vertical SKTextField에서 하드웨어 입력일 때 동작 후 포커스를 해제한다")
     func onSubmit_verticalTextView_withHardwareKeyboard() {
         let submitModel = SubmitModel()
         let uiTextView = makeTextView(

--- a/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
@@ -98,6 +98,44 @@ struct SKTextFieldTests {
         runMainLoop()
         #expect(uiTextField.isFirstResponder == false)
     }
+
+    @Test("focused(_:) 이후 onSubmit은 SKTextField modifier를 유지한다")
+    func focusedThenOnSubmit_bindBoolFocusState() {
+        let submitModel = SubmitModel()
+        let uiTextField = makeTextField(
+            rootView: FocusedSubmitBoolHostView(
+                submitModel: submitModel
+            )
+        )
+
+        let becomeFirstResponder = uiTextField.becomeFirstResponder()
+        runMainLoop()
+
+        _ = uiTextField.delegate?.textFieldShouldReturn?(uiTextField)
+        runMainLoop()
+
+        #expect(becomeFirstResponder == true)
+        #expect(submitModel.submitCount == 1)
+    }
+
+    @Test("focused(_:equals:) 이후 onSubmit은 SKTextField modifier를 유지한다")
+    func focusedThenOnSubmit_bindOptionalFocusState() {
+        let submitModel = SubmitModel()
+        let uiTextField = makeTextField(
+            rootView: FocusedSubmitValueHostView(
+                submitModel: submitModel
+            )
+        )
+
+        let becomeFirstResponder = uiTextField.becomeFirstResponder()
+        runMainLoop()
+
+        _ = uiTextField.delegate?.textFieldShouldReturn?(uiTextField)
+        runMainLoop()
+
+        #expect(becomeFirstResponder == true)
+        #expect(submitModel.submitCount == 1)
+    }
     
     @Test("horizontal SKTextField는 UITextField를 렌더링하고 바인딩 값을 반영한다")
     func horizontalTextField_rendersUIKitTextField() {
@@ -324,6 +362,40 @@ private extension SKTextFieldTests {
                 text: $text,
                 axis: .vertical
             )
+            .onSubmit {
+                submitModel.submitCount += 1
+            }
+        }
+    }
+
+    struct FocusedSubmitBoolHostView: View {
+        @ObservedObject var submitModel: SubmitModel
+        @State private var text = ""
+        @FocusState private var isFocused: Bool
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text
+            )
+            .focused($isFocused)
+            .onSubmit {
+                submitModel.submitCount += 1
+            }
+        }
+    }
+
+    struct FocusedSubmitValueHostView: View {
+        @ObservedObject var submitModel: SubmitModel
+        @State private var text = ""
+        @FocusState private var focusedField: SampleField?
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text
+            )
+            .focused($focusedField, equals: .plain)
             .onSubmit {
                 submitModel.submitCount += 1
             }

--- a/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldTests.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UIKit
 import Testing
 @testable import SwiftUI_Kit
 
@@ -139,6 +138,39 @@ struct SKTextFieldTests {
         #expect(uiTextView.text == "Multiline")
         #expect(uiTextView.textColor == .label)
     }
+
+    @Test("onSubmit은 horizontal SKTextField 제출 시 실행된다")
+    func onSubmit_horizontalTextField() {
+        let submitModel = SubmitModel()
+        let uiTextField = makeTextField(
+            rootView: SubmitHorizontalHostView(
+                submitModel: submitModel
+            )
+        )
+
+        _ = uiTextField.delegate?.textFieldShouldReturn?(uiTextField)
+
+        #expect(submitModel.submitCount == 1)
+    }
+
+    @Test("onSubmit은 vertical SKTextField 제출 시 실행된다")
+    func onSubmit_verticalTextView() {
+        let submitModel = SubmitModel()
+        let uiTextView = makeTextView(
+            rootView: SubmitVerticalHostView(
+                submitModel: submitModel
+            )
+        )
+
+        let shouldChange = uiTextView.delegate?.textView?(
+            uiTextView,
+            shouldChangeTextIn: NSRange(location: 0, length: 0),
+            replacementText: "\n"
+        )
+
+        #expect(shouldChange == false)
+        #expect(submitModel.submitCount == 1)
+    }
 }
 
 private extension SKTextFieldTests {
@@ -159,6 +191,11 @@ private extension SKTextFieldTests {
     @MainActor
     final class TextModel: ObservableObject {
         @Published var text = ""
+    }
+
+    @MainActor
+    final class SubmitModel: ObservableObject {
+        @Published var submitCount = 0
     }
     
     struct BoolFocusHostView: View {
@@ -229,6 +266,37 @@ private extension SKTextFieldTests {
                 ),
                 axis: .vertical
             )
+        }
+    }
+
+    struct SubmitHorizontalHostView: View {
+        @ObservedObject var submitModel: SubmitModel
+        @State private var text = ""
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text
+            )
+            .onSubmit {
+                submitModel.submitCount += 1
+            }
+        }
+    }
+
+    struct SubmitVerticalHostView: View {
+        @ObservedObject var submitModel: SubmitModel
+        @State private var text = ""
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text,
+                axis: .vertical
+            )
+            .onSubmit {
+                submitModel.submitCount += 1
+            }
         }
     }
     


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [x] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정
- [ ] CI: CI/CD 및 GitHub Actions 작업 및 수정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- `SKTextField` `onSubmit` modifier 지원 추가
- `onSubmit(of:)` 제거 및 `onSubmit(_:)` 단일 API 정리
- single line 입력에서 Return 입력 시 submit 후 포커스 해제 동작 연결
- multiline 입력에서 소프트웨어 키보드 Return 개행 유지 및 하드웨어 키보드 Return submit 후 포커스 해제 동작 연결
- `Coordinator` 본체 최소화 및 프로토콜별 delegate extension 분리
- `focused(...).onSubmit {}` 체인에서 `SKTextField` modifier 유지되도록 `focused` 반환 타입 정리
- `focused` 적용을 위한 내부 `focusModifier` 경로 추가
- `SKTextView` 분리 및 하드웨어 submit 처리 메서드 역할 주석 추가
- SampleApp `2. SKTextField` 디렉토리에 `onSubmit` 예제 화면 추가
- multiline 키보드별 동작 설명 문구 정리
- single line / multiline submit 동작 및 focused 이후 onSubmit 체인 검증 테스트 추가

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #17

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|테스트 코드 결과|<img src = "https://github.com/user-attachments/assets/c79f61df-ec50-4ba1-a540-72f01a085a92" width ="300">|

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->
- 하드웨어, 소프트웨어 키보드 입력에 따른 `onSubmit` 적용 형태는 SwiftUI의 `TextField(_:text:axis:)`의 동작을 카피한 형태인데 괜찮은 생각인지 판단이 필요함
- `onSubmit` API를 `.text` 전용 단일 modifier로 단순화한 상태
- `focused`는 `Self`를 유지하되 내부 `body`에서 SwiftUI `focused` modifier를 다시 적용하는 방식으로 정리한 상태
- 현재 의도한 입력 동작 기준
  - single line: 소프트웨어/하드웨어 Return 모두 submit 후 포커스 해제
  - multiline: 소프트웨어 Return 개행 유지, 하드웨어 Return만 submit 후 포커스 해제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 텍스트 입력 필드에 onSubmit 제출 처리 추가 — 싱글라인/멀티라인 구분 적용
  * 하드웨어 키보드의 Return/Enter로 제출 가능하도록 지원
  * 마지막 제출값 및 제출 횟수를 표시하고 상태 초기화하는 새 데모 탭 추가

* **테스트**
  * 소프트/하드웨어 키보드 및 축(가로/세로)별 제출 동작 관련 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->