### PR TITLE
[#19] submitLabel 모디파이어를 구현한다

### DIFF
--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldSubmitLabelTabView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldSubmitLabelTabView.swift
@@ -1,0 +1,138 @@
+//
+//  SampleSKTextFieldSubmitLabelTabView.swift
+//  SwiftUI-Kit
+//
+//  Created by opfic on 4/28/26.
+//
+
+import SwiftUI
+import SwiftUI_Kit
+
+struct SampleSKTextFieldSubmitLabelTabView: View {
+    @State private var texts = [SampleSKTextFieldSubmitLabelItem.ID: String]()
+
+    private let items = SampleSKTextFieldSubmitLabelItem.allCases
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(items) { item in
+                        SampleSKTextFieldSubmitLabelRow(
+                            item: item,
+                            text: binding(for: item)
+                        )
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("submitLabel")
+        }
+    }
+
+    private func binding(
+        for item: SampleSKTextFieldSubmitLabelItem
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                texts[item.id, default: ""]
+            },
+            set: { newValue in
+                texts[item.id] = newValue
+            }
+        )
+    }
+}
+
+private struct SampleSKTextFieldSubmitLabelRow: View {
+    let item: SampleSKTextFieldSubmitLabelItem
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(item.title)
+                .font(.headline)
+            Text(item.code)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            SKTextField(
+                item.placeholder,
+                text: $text
+            )
+            .submitLabel(item.submitLabel)
+            Text("입력 값: \(text.isEmpty ? "비어 있음" : text)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private enum SampleSKTextFieldSubmitLabelItem: String, CaseIterable, Identifiable {
+    case `continue`
+    case done
+    case go
+    case join
+    case next
+    case `return`
+    case route
+    case search
+    case send
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .continue:
+            return "Continue"
+        case .done:
+            return "Done"
+        case .go:
+            return "Go"
+        case .join:
+            return "Join"
+        case .next:
+            return "Next"
+        case .return:
+            return "Return"
+        case .route:
+            return "Route"
+        case .search:
+            return "Search"
+        case .send:
+            return "Send"
+        }
+    }
+
+    var code: String {
+        ".submitLabel(.\(rawValue))"
+    }
+
+    var placeholder: String {
+        "\(title) label"
+    }
+
+    var submitLabel: SubmitLabel {
+        switch self {
+        case .continue:
+            return .continue
+        case .done:
+            return .done
+        case .go:
+            return .go
+        case .join:
+            return .join
+        case .next:
+            return .next
+        case .return:
+            return .return
+        case .route:
+            return .route
+        case .search:
+            return .search
+        case .send:
+            return .send
+        }
+    }
+}

--- a/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldView.swift
+++ b/Examples/SampleApp/SampleApp/View/Wrapper/2. SKTextField/SampleSKTextFieldView.swift
@@ -30,6 +30,11 @@ public struct SampleSKTextFieldView: View {
                 .tabItem {
                     Label("onSubmit", systemImage: "arrow.turn.down.left")
                 }
+
+            SampleSKTextFieldSubmitLabelTabView()
+                .tabItem {
+                    Label("submitLabel", systemImage: "keyboard")
+                }
         }
     }
 }

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextField.swift
@@ -47,6 +47,7 @@ public struct SKTextField<Label: View>: View {
     private var onFocusChange: ((Bool) -> Void)?
     private var focusModifier: ((AnyView) -> AnyView)?
     private var onSubmitAction: (() -> Void)?
+    private var submitLabel: SubmitLabel?
     
     /// 로컬라이즈된 제목 문자열로 텍스트 필드를 생성합니다.
     ///
@@ -145,6 +146,7 @@ public struct SKTextField<Label: View>: View {
                 axis: axis,
                 placeholder: placeholder,
                 accessibilityLabel: accessibilityLabel,
+                submitLabel: submitLabel,
                 onSubmit: submitAction,
                 focusBinding: {
                     if let focusValue, let onFocusChange {
@@ -206,6 +208,26 @@ public struct SKTextField<Label: View>: View {
             previousAction?()
             action()
         }
+        return copy
+    }
+
+    /// 키보드 Return 버튼의 표시 방식을 설정합니다.
+    ///
+    /// SwiftUI `View.submitLabel(_:)`와 같은 형태로 사용할 수 있습니다.
+    /// `submitLabel`은 키보드 Return 버튼의 표시만 변경하며, submit 동작은 `onSubmit`으로 등록합니다.
+    ///
+    /// ## 사용 예시
+    /// ```swift
+    /// @State private var keyword = ""
+    ///
+    /// SKTextField("검색", text: $keyword)
+    ///     .submitLabel(.search)
+    /// ```
+    ///
+    /// - Parameter submitLabel: 키보드 Return 버튼에 표시할 submit label입니다.
+    public func submitLabel(_ submitLabel: SubmitLabel) -> Self {
+        var copy = self
+        copy.submitLabel = submitLabel
         return copy
     }
     

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -12,6 +12,7 @@ struct SKTextFieldPresentable: UIViewRepresentable {
     let axis: Axis
     let placeholder: String
     let accessibilityLabel: String?
+    let submitLabel: SubmitLabel?
     let onSubmit: (() -> Void)?
     let focusBinding: Binding<Bool>?
 
@@ -117,10 +118,12 @@ extension SKTextFieldPresentable {
             container.uiTextView?.accessibilityLabel = parent.accessibilityLabel
 
             if let uiTextField = container.uiTextField {
+                uiTextField.returnKeyType = parent.submitLabel.returnKeyType
                 applyPlaceholder(to: uiTextField)
             }
 
             if let uiTextView = container.uiTextView {
+                uiTextView.returnKeyType = parent.submitLabel.returnKeyType
                 applyPlaceholderIfNeeded(to: uiTextView)
                 if parent.onSubmit == nil {
                     uiTextView.onHardwareSubmit = nil

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -118,12 +118,18 @@ extension SKTextFieldPresentable {
             container.uiTextView?.accessibilityLabel = parent.accessibilityLabel
 
             if let uiTextField = container.uiTextField {
-                uiTextField.returnKeyType = parent.submitLabel.returnKeyType
+                let returnKeyType = parent.submitLabel.returnKeyType
+                if uiTextField.returnKeyType != returnKeyType {
+                    uiTextField.returnKeyType = returnKeyType
+                }
                 applyPlaceholder(to: uiTextField)
             }
 
             if let uiTextView = container.uiTextView {
-                uiTextView.returnKeyType = parent.submitLabel.returnKeyType
+                let returnKeyType = parent.submitLabel.returnKeyType
+                if uiTextView.returnKeyType != returnKeyType {
+                    uiTextView.returnKeyType = returnKeyType
+                }
                 applyPlaceholderIfNeeded(to: uiTextView)
                 if parent.onSubmit == nil {
                     uiTextView.onHardwareSubmit = nil

--- a/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
+++ b/Sources/SwiftUI-Kit/Wrapper/SKTextField/SKTextFieldPresentable.swift
@@ -324,6 +324,49 @@ extension SKTextFieldPresentable.Coordinator: UITextViewDelegate {
     }
 }
 
+private extension Optional where Wrapped == SubmitLabel {
+    var returnKeyType: UIReturnKeyType {
+        guard let self else {
+            return .default
+        }
+
+        return self.returnKeyType
+    }
+}
+
+private extension SubmitLabel {
+    var returnKeyType: UIReturnKeyType {
+        guard let role = Mirror(reflecting: self).children.first(
+            where: { $0.label == "role" }
+        )?.value else {
+            return .default
+        }
+
+        switch String(describing: role) {
+        case "continue":
+            return .continue
+        case "done":
+            return .done
+        case "go":
+            return .go
+        case "join":
+            return .join
+        case "next":
+            return .next
+        case "return":
+            return .default
+        case "route":
+            return .route
+        case "search":
+            return .search
+        case "send":
+            return .send
+        default:
+            return .default
+        }
+    }
+}
+
 private extension UIView {
     var enclosingScrollView: UIScrollView? {
         var currentSuperview = superview

--- a/Tests/SwiftUI-KitTests/SKTextFieldSubmitLabelTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldSubmitLabelTests.swift
@@ -1,0 +1,151 @@
+//
+//  SKTextFieldSubmitLabelTests.swift
+//  SwiftUI-Kit
+//
+//  Created by opfic on 4/28/26.
+//
+
+import SwiftUI
+import Testing
+@testable import SwiftUI_Kit
+
+@MainActor
+struct SKTextFieldSubmitLabelTests {
+
+    @Test("submitLabel은 모든 SubmitLabel 값을 UITextField returnKeyType으로 매핑한다")
+    func submitLabel_mapsAllCasesToTextFieldReturnKeyType() {
+        let cases = [
+            (SubmitLabel.continue, UIReturnKeyType.continue),
+            (.done, .done),
+            (.go, .go),
+            (.join, .join),
+            (.next, .next),
+            (.return, .default),
+            (.route, .route),
+            (.search, .search),
+            (.send, .send)
+        ]
+
+        for (submitLabel, expectedReturnKeyType) in cases {
+            let uiTextField = makeTextField(
+                rootView: SubmitLabelHorizontalHostView(
+                    submitLabel: submitLabel
+                )
+            )
+
+            #expect(uiTextField.returnKeyType == expectedReturnKeyType)
+        }
+    }
+
+    @Test("submitLabel은 UITextView returnKeyType에 반영된다")
+    func submitLabel_appliesToTextViewReturnKeyType() {
+        let uiTextView = makeTextView(
+            rootView: SubmitLabelVerticalHostView(
+                submitLabel: .search
+            )
+        )
+
+        #expect(uiTextView.returnKeyType == .search)
+    }
+}
+
+private extension SKTextFieldSubmitLabelTests {
+    struct SubmitLabelHorizontalHostView: View {
+        let submitLabel: SubmitLabel
+        @State private var text = ""
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text
+            )
+            .submitLabel(submitLabel)
+        }
+    }
+
+    struct SubmitLabelVerticalHostView: View {
+        let submitLabel: SubmitLabel
+        @State private var text = ""
+
+        var body: some View {
+            SKTextField(
+                "Title",
+                text: $text,
+                axis: .vertical
+            )
+            .submitLabel(submitLabel)
+        }
+    }
+
+    func makeTextField<Content: View>(
+        rootView: Content
+    ) -> UITextField {
+        let uiWindow = UIWindow(
+            frame: UIScreen.main.bounds
+        )
+        let uiHostingController = UIHostingController(
+            rootView: rootView
+        )
+
+        uiWindow.rootViewController = uiHostingController
+        uiWindow.makeKeyAndVisible()
+        runMainLoop()
+
+        return findTextField(in: uiHostingController.view)
+        ?? UITextField()
+    }
+
+    func makeTextView<Content: View>(
+        rootView: Content
+    ) -> UITextView {
+        let uiWindow = UIWindow(
+            frame: UIScreen.main.bounds
+        )
+        let uiHostingController = UIHostingController(
+            rootView: rootView
+        )
+
+        uiWindow.rootViewController = uiHostingController
+        uiWindow.makeKeyAndVisible()
+        runMainLoop()
+
+        return findTextView(in: uiHostingController.view)
+        ?? UITextView()
+    }
+
+    func findTextField(in view: UIView) -> UITextField? {
+        if let uiTextField = view as? UITextField {
+            return uiTextField
+        }
+
+        for subview in view.subviews {
+            if let uiTextField = findTextField(in: subview) {
+                return uiTextField
+            }
+        }
+
+        return nil
+    }
+
+    func findTextView(in view: UIView) -> UITextView? {
+        if let uiTextView = view as? UITextView {
+            return uiTextView
+        }
+
+        for subview in view.subviews {
+            if let uiTextView = findTextView(in: subview) {
+                return uiTextView
+            }
+        }
+
+        return nil
+    }
+
+    func runMainLoop() {
+        for _ in 0..<5 {
+            RunLoop.main.run(
+                until: Date().addingTimeInterval(0.01)
+            )
+        }
+    }
+}

--- a/Tests/SwiftUI-KitTests/SKTextFieldSubmitLabelTests.swift
+++ b/Tests/SwiftUI-KitTests/SKTextFieldSubmitLabelTests.swift
@@ -13,7 +13,7 @@ import Testing
 struct SKTextFieldSubmitLabelTests {
 
     @Test("submitLabel은 모든 SubmitLabel 값을 UITextField returnKeyType으로 매핑한다")
-    func submitLabel_mapsAllCasesToTextFieldReturnKeyType() {
+    func submitLabel_mapsAllCasesToTextFieldReturnKeyType() throws {
         let cases = [
             (SubmitLabel.continue, UIReturnKeyType.continue),
             (.done, .done),
@@ -27,7 +27,7 @@ struct SKTextFieldSubmitLabelTests {
         ]
 
         for (submitLabel, expectedReturnKeyType) in cases {
-            let uiTextField = makeTextField(
+            let uiTextField = try makeTextField(
                 rootView: SubmitLabelHorizontalHostView(
                     submitLabel: submitLabel
                 )
@@ -38,8 +38,8 @@ struct SKTextFieldSubmitLabelTests {
     }
 
     @Test("submitLabel은 UITextView returnKeyType에 반영된다")
-    func submitLabel_appliesToTextViewReturnKeyType() {
-        let uiTextView = makeTextView(
+    func submitLabel_appliesToTextViewReturnKeyType() throws {
+        let uiTextView = try makeTextView(
             rootView: SubmitLabelVerticalHostView(
                 submitLabel: .search
             )
@@ -79,7 +79,7 @@ private extension SKTextFieldSubmitLabelTests {
 
     func makeTextField<Content: View>(
         rootView: Content
-    ) -> UITextField {
+    ) throws -> UITextField {
         let uiWindow = UIWindow(
             frame: UIScreen.main.bounds
         )
@@ -91,13 +91,12 @@ private extension SKTextFieldSubmitLabelTests {
         uiWindow.makeKeyAndVisible()
         runMainLoop()
 
-        return findTextField(in: uiHostingController.view)
-        ?? UITextField()
+        return try #require(findTextField(in: uiHostingController.view))
     }
 
     func makeTextView<Content: View>(
         rootView: Content
-    ) -> UITextView {
+    ) throws -> UITextView {
         let uiWindow = UIWindow(
             frame: UIScreen.main.bounds
         )
@@ -109,8 +108,7 @@ private extension SKTextFieldSubmitLabelTests {
         uiWindow.makeKeyAndVisible()
         runMainLoop()
 
-        return findTextView(in: uiHostingController.view)
-        ?? UITextView()
+        return try #require(findTextView(in: uiHostingController.view))
     }
 
     func findTextField(in view: UIView) -> UITextField? {


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정
- [ ] CI: CI/CD 및 GitHub Actions 작업 및 수정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- `SKTextField.submitLabel(_:)` modifier 추가
- `SwiftUI.SubmitLabel`을 `UIReturnKeyType`으로 매핑하는 UIKit bridge 처리 추가
- `UITextField`와 `UITextView`의 Return 키 label 반영 지원
- `SubmitLabel` 전체 케이스 매핑 테스트 추가
- SampleApp에 `submitLabel` 예제 추가

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #19

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/d2076d37-be4e-44d2-9639-e0c40e7d156b" width="250">
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/519641fd-c6b5-4da8-bff0-91a8166083b0" width="250">
    </td>
  </tr>
  <tr>
    <th>샘플 앱</th>
    <th>테스트 코드 결과</th>
  </tr>
</table>

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->
- `submitLabel`은 키보드 Return 버튼 표시만 변경하고, submit 동작은 기존 `onSubmit` 로직과 분리
- `SubmitLabel`은 공개 API상 직접 비교할 수 없어 `Mirror` 기반 role 추출 후 `UIReturnKeyType`으로 매핑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * SKTextField에 키보드 Return 버튼 레이블을 커스터마이징할 수 있는 submitLabel 기능이 추가되었습니다.
  * submitLabel 설정을 시연하는 새 샘플 화면과 해당 탭이 샘플 앱에 추가되었습니다.

* **Tests**
  * submitLabel 동작(각 레이블에 따른 키보드 Return 타입 매핑)을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->